### PR TITLE
Remove noisy console.log from setupIndexedDb

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -8,7 +8,6 @@ async function setupIndexedDB(config: IndexedDBConfig) {
   return new Promise<void>(async (resolve, reject) => {
     try {
       await getConnection(config);
-      console.log("inside Init", config);
       window[IDB_KEY] = { init: 1, config };
       resolve();
     } catch (e) {


### PR DESCRIPTION
`setupIndexedDb` currently runs a `console.log` with the config every time it's called. I'd rather not show this to my users.