### PR TITLE
chore: add actions getter for use outside React

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -23,4 +23,6 @@ export function useIndexedDBStore<T>(storeName: string) {
   return _actions;
 }
 
+export const getIndexedDBStore = getActions;
+
 export default setupIndexedDB;


### PR DESCRIPTION
Makes it possible to reuse the package's main functionality outside of React (e.g., in service workers).